### PR TITLE
update webmock version

### DIFF
--- a/lib/webpay/mock/webmock_wrapper.rb
+++ b/lib/webpay/mock/webmock_wrapper.rb
@@ -123,7 +123,7 @@ module WebPay::Mock::WebMockWrapper
         { body: response.to_json }
       end
 
-    stub_request(method, base_url + path).with(query: hash_including({})).with(params).to_return(spec)
+    stub_request(method, base_url + path).with(query: hash_including({})).with(body: params).to_return(spec)
 
     JSON.parse(spec[:body])
   end

--- a/spec/webmock_wrapper_spec.rb
+++ b/spec/webmock_wrapper_spec.rb
@@ -56,7 +56,7 @@ describe WebPay::Mock::WebMockWrapper do
     describe 'refund' do
       let(:id) { 'ch_xxxxxxxxx' }
       let(:data) { charge_from({amount: 5000}, id: id) }
-      let!(:refunded) { webpay_stub(:charges, :refund, params: { 'amount' => data['amount'] }, base: data) }
+      let!(:refunded) { webpay_stub(:charges, :refund, body: { params: { 'amount' => data['amount'] } }, base: data) }
       specify { expect(webpay.charge.refund(id).refunded).to eq true }
     end
 
@@ -121,7 +121,7 @@ describe WebPay::Mock::WebMockWrapper do
   describe 'recursios' do
     describe 'create' do
       let(:params) { { amount: 1000, currency: 'jpy', customer: 'cus_xxxxxxxxx', period: 'month', description: 'test charge' } }
-      let!(:response) { webpay_stub(:recursion, :create, params: params) }
+      let!(:response) { webpay_stub(:recursion, :create, body: { params: params }) }
       specify { expect(webpay.recursion.create({}).id).to eq response['id'] }
     end
 
@@ -161,7 +161,7 @@ describe WebPay::Mock::WebMockWrapper do
           :exp_year=>"2019",
           :cvc=>"123",
           :name=>"KIYOKI IPPYO"} }
-      let!(:response) { webpay_stub(:tokens, :create, params: card_params) }
+      let!(:response) { webpay_stub(:tokens, :create, body: { params: card_params }) }
       specify { expect(webpay.token.create(card: card_params).id).to eq response['id'] }
     end
 

--- a/webpay-mock.gemspec
+++ b/webpay-mock.gemspec
@@ -18,11 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  if RUBY_VERSION >= '1.9.3'
-    spec.add_dependency 'webmock', '~> 2.0.0'
-  else
-    spec.add_dependency 'webmock', '~> 1.18.0'
-  end
+  spec.add_dependency 'webmock', '~> 2.0.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/webpay-mock.gemspec
+++ b/webpay-mock.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'webmock', '~> 1.18.0'
+  if RUBY_VERSION >= '1.9.3'
+    spec.add_dependency 'webmock', '~> 2.0.0'
+  else
+    spec.add_dependency 'webmock', '~> 1.18.0'
+  end
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
[Webmock gem dropped support for Ruby < 1.9.3](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#200) when the gem had been updated to v2.0.0.

So I changed `gemspec` file. Thank you!