### PR TITLE
update bundler before ci execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - jruby-head
   - jruby-1.7
   - rbx-2.2.7
+before_install:
+  - gem update bundler
 script: "bundle exec rake"
 notifications:
   hipchat:

--- a/webpay-mock.gemspec
+++ b/webpay-mock.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'webmock', '~> 1.18.0'
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.12.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'webpay', '~> 3.0'


### PR DESCRIPTION
Travis CI in https://github.com/webpay/webpay-mock/pull/8 says

```
NoMethodError: undefined method `spec' for nil:NilClass
```

I update bundler version. If this Pull Request is merged CI of https://github.com/webpay/webpay-mock/pull/8 will be passed.