### PR TITLE
Modify spec of WebPay::Charge#retrieve that doesn't covered

### DIFF
--- a/spec/webmock_wrapper_spec.rb
+++ b/spec/webmock_wrapper_spec.rb
@@ -47,10 +47,9 @@ describe WebPay::Mock::WebMockWrapper do
     end
 
     describe 'retrieve responds not found' do
-      let(:params) { { amount: 1000, currency: 'jpy', card: 'tok_xxxxxxxxx', description: 'test charge' } }
-      let!(:response) { webpay_stub(:charges, :create, error: :not_found, params: params) }
-
-      specify { expect { webpay.charge.create(params).id }.to raise_error(WebPay::ErrorResponse::InvalidRequestError) }
+      let(:id) { 'ch_xxxxxxxxx' }
+      before { webpay_stub(:charges, :retrieve, error: :not_found, id: id) }
+      specify { expect { webpay.charge.retrieve(id).id }.to raise_error(WebPay::ErrorResponse::InvalidRequestError) }
     end
 
     describe 'refund' do


### PR DESCRIPTION
According to [this line] (https://github.com/webpay/webpay-mock/blob/master/spec/webmock_wrapper_spec.rb#L49-L54), the spec for `WebPay::Charge#retrieve` doesn't covered failure case of API request. (maybe duplicate spec of `#create` has been placed by mistake?)

So I added the test case for that. 